### PR TITLE
Fixes the build when using a custom path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
       shell: "bash"
       env:
         PACKAGE_MANAGER: ${{ steps.lockfile.outputs.PACKAGE_MANAGER }}
-      run: $node_pm run build
+      run: $node_pm run --prefix ${{ inputs.path }} build
 
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
This let's the action to run when the project is not located in the root folder (and the user specifics a custom path as input)