### PR TITLE
Updated README.md to line up with the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ jobs:
         uses: actions/checkout@v2          
       - name: Install, build, and upload your site output
         uses: withastro/action@v0
+        # with:
+            # path: . # The root location of your Astro project inside the repository. (optional)
+            # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
+            # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:
     needs: build


### PR DESCRIPTION
This updates the README.md file example to line up with the docs.astro.build copy (withastro/docs#1718)