### PR TITLE
Moved away from set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,25 +28,24 @@ runs:
       run: |
         len=`echo $INPUT_PM | wc -c`
         if [ $len -gt 1 ]; then
-            echo "::set-output name=PACKAGE_MANAGER::$INPUT_PM"
+            echo "PACKAGE_MANAGER=$INPUT_PM" >> $GITHUB_ENV
             echo "node_pm=$INPUT_PM" >> $GITHUB_ENV
         elif [ $(find "." -name "pnpm-lock.yaml") ]; then
-            echo "::set-output name=PACKAGE_MANAGER::pnpm"
+            echo "PACKAGE_MANAGER=pnpm" >> $GITHUB_ENV
             echo "node_pm=pnpm" >> $GITHUB_ENV
         elif [ $(find "." -name "yarn.lock") ]; then 
-            echo "::set-output name=PACKAGE_MANAGER::yarn"
+            echo "PACKAGE_MANAGER=yarn" >> $GITHUB_ENV
             echo "node_pm=yarn" >> $GITHUB_ENV
         elif [ $(find "." -name "package-lock.json") ]; then 
-            echo "::set-output name=PACKAGE_MANAGER::npm"
+            echo "PACKAGE_MANAGER=npm" >> $GITHUB_ENV
             echo "node_pm=npm" >> $GITHUB_ENV
         else
             echo "No lockfile found.
         Please specify your preferred \"package-manager\" in the action configuration."
             exit 1
         fi
-
     - name: Setup PNPM
-      if: ${{ steps.lockfile.outputs.PACKAGE_MANAGER == 'pnpm' }}
+      if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
       uses: pnpm/action-setup@v2.2.2
       with:
         version: 7.x.x
@@ -55,22 +54,20 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
-        cache: ${{ steps.lockfile.outputs.PACKAGE_MANAGER }}
+        cache: ${{ env.PACKAGE_MANAGER }}
 
     - name: Install
       shell: "bash"
       run: |
         cd ${{ inputs.path }}
         $node_pm install
-
     - name: Build
       shell: "bash"
       env:
-        PACKAGE_MANAGER: ${{ steps.lockfile.outputs.PACKAGE_MANAGER }}
+        PACKAGE_MANAGER: ${{ env.PACKAGE_MANAGER }}
       run: |
         cd ${{ inputs.path }}
         $node_pm run build
-
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v1
       with:


### PR DESCRIPTION
This changes the action to use environment variables instead of the set-output command because it’s being deprecated
![C60E8405-06B9-4BB3-BD02-18CFFB7CA11F](https://user-images.githubusercontent.com/49076509/195429734-8daf628e-2ad6-4641-98cd-b9e2c291c088.jpeg)
The warning is still being thrown but that’s because of the external setup-node action. The warning thrown by this action are gone now 