### PR TITLE
Use actions/checkout@v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v2          
+        uses: actions/checkout@v3
       - name: Install, build, and upload your site output
         uses: withastro/action@v0
         # with:


### PR DESCRIPTION
Hello!

The v2 of checkout started giving a warning:

![image](https://user-images.githubusercontent.com/24359130/200015857-f3bef42a-0f17-4bfa-a62d-1ff3e8d9c526.png)

Switching to v3 fixes it, and seems to work identically. Tested deployment on my website, seems to work fine.

If this gets accepted I'll also make a PR to update the documentation to reflect the change.