### PR TITLE
Optional cache-dependency-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ For more information, please see our complete deployment guide—[Deploy your As
 - `path` - Optional: the root location of your Astro project inside the repository.
 - `node-version` - Optional: the specific version of Node that should be used to build your site. Defaults to `16`.
 - `package-manager` - Optional: the Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile.
+- `resolve-dep-from-path` - Optional: If the dependency file should be resolved from the root location of your Astro project. Defaults to `true`.
 
 ### Example workflow:
 
@@ -49,6 +50,7 @@ jobs:
             # path: . # The root location of your Astro project inside the repository. (optional)
             # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
             # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+            # resolve-dep-from-path: false # If the dependency file should be resolved from the root location of your Astro project. Defaults to `true`. (optional)
 
   deploy:
     needs: build

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,11 @@ inputs:
     description: "If not automatically detectable, you may specify your preferred package manager"
     required: false
     default: ""
+  resolve-dep-from-path:
+    description: "If the dependency file is located inside the folder specified by path" 
+    type: boolean
+    required: false
+    default: true 
 
 runs:
   using: composite
@@ -50,10 +55,18 @@ runs:
 
     - name: Setup Node
       uses: actions/setup-node@v3
+      if: inputs.resolve-dep-from-path == true 
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ env.PACKAGE_MANAGER }}
         cache-dependency-path: "${{ inputs.path }}/${{ env.LOCKFILE }}"
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      if: inputs.resolve-dep-from-path == false 
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ env.PACKAGE_MANAGER }}
 
     - name: Install
       shell: "bash"


### PR DESCRIPTION
Introduced a new input variable called `resolve-dep-from-path`.

Using this, a user can opt if they want to locate the dependency file (the lock files etc.) from inside the folder specified by `path`. Defaults to `true`.

This will come handy for monorepo projects. Also fixes #21.