### PR TITLE
Support Bun package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ jobs:
       - name: Install, build, and upload your site output
         uses: withastro/action@v0
         # with:
-        # path: . # The root location of your Astro project inside the repository. (optional)
-        # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
-        # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-        # resolve-dep-from-path: false # If the dependency file should be resolved from the root location of your Astro project. Defaults to `true`. (optional)
+            # path: . # The root location of your Astro project inside the repository. (optional)
+            # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
+            # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+            # resolve-dep-from-path: false # If the dependency file should be resolved from the root location of your Astro project. Defaults to `true`. (optional)
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information, please see our complete deployment guide—[Deploy your As
 
 - `path` - Optional: the root location of your Astro project inside the repository.
 - `node-version` - Optional: the specific version of Node that should be used to build your site. Defaults to `16`.
-- `package-manager` - Optional: the Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile.
+- `package-manager` - Optional: the Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. Accepted values: `npm`, `yarn`, `pnpm`, and `bun`.
 - `resolve-dep-from-path` - Optional: If the dependency file should be resolved from the root location of your Astro project. Defaults to `true`.
 
 ### Example workflow:
@@ -28,10 +28,10 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [ main ]
+    branches: [main]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
-  
+
 # Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
@@ -47,10 +47,10 @@ jobs:
       - name: Install, build, and upload your site output
         uses: withastro/action@v0
         # with:
-            # path: . # The root location of your Astro project inside the repository. (optional)
-            # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
-            # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-            # resolve-dep-from-path: false # If the dependency file should be resolved from the root location of your Astro project. Defaults to `true`. (optional)
+        # path: . # The root location of your Astro project inside the repository. (optional)
+        # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
+        # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        # resolve-dep-from-path: false # If the dependency file should be resolved from the root location of your Astro project. Defaults to `true`. (optional)
 
   deploy:
     needs: build

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       if: ${{ env.PACKAGE_MANAGER == 'bun' }}
       uses: oven-sh/setup-bun@v1
       with:
-        version: latest
+        bun-version: latest
 
     - name: Setup Node
       uses: actions/setup-node@v3

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ runs:
         elif [ $(find "." -name "package-lock.json") ]; then 
             echo "PACKAGE_MANAGER=npm" >> $GITHUB_ENV
             echo "LOCKFILE=package-lock.json" >> $GITHUB_ENV
+        elif [ $(find "." -name "bun.lockb") ]; then 
+            echo "PACKAGE_MANAGER=bun" >> $GITHUB_ENV
+            echo "LOCKFILE=bun.lockb" >> $GITHUB_ENV
         else
             echo "No lockfile found.
         Please specify your preferred \"package-manager\" in the action configuration."
@@ -52,6 +55,12 @@ runs:
       uses: pnpm/action-setup@v2.2.4
       with:
         version: 7.x.x
+    
+    - name: Setup Bun
+      if: ${{ env.PACKAGE_MANAGER == 'bun' }}
+      uses: oven-sh/setup-bun@v1
+      with:
+        version: latest
 
     - name: Setup Node
       uses: actions/setup-node@v3

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,10 @@ inputs:
     required: false
     default: ""
   resolve-dep-from-path:
-    description: "If the dependency file is located inside the folder specified by path" 
+    description: "If the dependency file is located inside the folder specified by path"
     type: boolean
     required: false
-    default: true 
+    default: true
 
 runs:
   using: composite
@@ -50,12 +50,17 @@ runs:
         Please specify your preferred \"package-manager\" in the action configuration."
             exit 1
         fi
+
+    - name: Print PACKAGE_MANAGER
+      shell: "bash"
+      run: |
+        echo $PACKAGE_MANAGER
     - name: Setup PNPM
       if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
       uses: pnpm/action-setup@v2.2.4
       with:
         version: 7.x.x
-    
+
     - name: Setup Bun
       if: ${{ env.PACKAGE_MANAGER == 'bun' }}
       uses: oven-sh/setup-bun@v1
@@ -64,7 +69,7 @@ runs:
 
     - name: Setup Node
       uses: actions/setup-node@v3
-      if: inputs.resolve-dep-from-path == true 
+      if: inputs.resolve-dep-from-path == true
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ env.PACKAGE_MANAGER }}
@@ -72,7 +77,7 @@ runs:
 
     - name: Setup Node
       uses: actions/setup-node@v3
-      if: inputs.resolve-dep-from-path == false 
+      if: inputs.resolve-dep-from-path == false
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ env.PACKAGE_MANAGER }}
@@ -88,8 +93,3 @@ runs:
       run: |
         cd ${{ inputs.path }}
         $PACKAGE_MANAGER run build
-
-    - name: Upload Pages Artifact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: "${{ inputs.path }}/dist/"

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,10 @@ inputs:
     required: false
     default: ""
   resolve-dep-from-path:
-    description: "If the dependency file is located inside the folder specified by path"
+    description: "If the dependency file is located inside the folder specified by path" 
     type: boolean
     required: false
-    default: true
+    default: true 
 
 runs:
   using: composite
@@ -50,17 +50,12 @@ runs:
         Please specify your preferred \"package-manager\" in the action configuration."
             exit 1
         fi
-
-    - name: Print PACKAGE_MANAGER
-      shell: "bash"
-      run: |
-        echo $PACKAGE_MANAGER
     - name: Setup PNPM
       if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
       uses: pnpm/action-setup@v2.2.4
       with:
         version: 7.x.x
-
+    
     - name: Setup Bun
       if: ${{ env.PACKAGE_MANAGER == 'bun' }}
       uses: oven-sh/setup-bun@v1
@@ -69,7 +64,7 @@ runs:
 
     - name: Setup Node
       uses: actions/setup-node@v3
-      if: inputs.resolve-dep-from-path == true
+      if: inputs.resolve-dep-from-path == true 
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ env.PACKAGE_MANAGER }}
@@ -77,7 +72,7 @@ runs:
 
     - name: Setup Node
       uses: actions/setup-node@v3
-      if: inputs.resolve-dep-from-path == false
+      if: inputs.resolve-dep-from-path == false 
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ env.PACKAGE_MANAGER }}
@@ -93,3 +88,8 @@ runs:
       run: |
         cd ${{ inputs.path }}
         $PACKAGE_MANAGER run build
+
+    - name: Upload Pages Artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: "${{ inputs.path }}/dist/"


### PR DESCRIPTION
This PR updates the action to infer usage of the Bun package manager based on existence of `bun.lockb`. If `package-manager: bun` is set or if a `bun.lockb` is detected, Bun will be installed using the [setup-bun](https://github.com/oven-sh/setup-bun) action and used to install dependencies.

The updated action has been tested here: https://github.com/colinhacks/astro-action-check/actions/runs/5756396287