### PR TITLE
Fix issue with packager installation if path is not repository root

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ runs:
   steps:
     - name: Check lockfiles
       shell: "bash"
+      working-directory: ${{ inputs.path }}
       env:
         INPUT_PM: ${{ inputs.package-manager }}
       run: |
@@ -82,17 +83,16 @@ runs:
 
     - name: Install
       shell: "bash"
-      run: |
-        cd ${{ inputs.path }}
-        $PACKAGE_MANAGER install
+      working-directory: ${{ inputs.path }}
+      run: $PACKAGE_MANAGER install
 
     - name: Build
       shell: "bash"
-      run: |
-        cd ${{ inputs.path }}
-        $PACKAGE_MANAGER run build
+      working-directory: ${{ inputs.path }}
+      run: $PACKAGE_MANAGER run build
 
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v1
+      working-directory: ${{ inputs.path }}
       with:
-        path: "${{ inputs.path }}/dist/"
+        path: "dist"


### PR DESCRIPTION
If you try to use this action with a `path` option specified other than `.`, the action fails with the following message:

```sh
Run withastro/action@v1
  with:
    path: docs
    package-manager: yarn
    node-version: 18
Run len=`echo $INPUT_PM | wc -c`
  len=`echo $INPUT_PM | wc -c`
  if [ $len -gt 1 ]; then
    PACKAGE_MANAGER=$(echo "$INPUT_PM" | grep -o '^[^@]*')
    VERSION=$(echo "$INPUT_PM" | grep -o '@.*' | sed 's/^@//')
    # Set default VERSION if not provided
    if [ -z "$VERSION" ]; then
        VERSION="latest"
    fi
    echo "PACKAGE_MANAGER=$PACKAGE_MANAGER" >> $GITHUB_ENV
  elif [ $(find "." -name "pnpm-lock.yaml") ]; then
      echo "PACKAGE_MANAGER=pnpm" >> $GITHUB_ENV
      echo "LOCKFILE=pnpm-lock.yaml" >> $GITHUB_ENV
  elif [ $(find "." -name "yarn.lock") ]; then 
      echo "PACKAGE_MANAGER=yarn" >> $GITHUB_ENV
      echo "LOCKFILE=yarn.lock" >> $GITHUB_ENV
  elif [ $(find "." -name "package-lock.json") ]; then 
      VERSION="latest"
      echo "PACKAGE_MANAGER=npm" >> $GITHUB_ENV
      echo "LOCKFILE=package-lock.json" >> $GITHUB_ENV
  elif [ $(find "." -name "bun.lockb") ]; then 
      VERSION="latest"
      echo "PACKAGE_MANAGER=bun" >> $GITHUB_ENV
      echo "LOCKFILE=bun.lockb" >> $GITHUB_ENV
  else
      echo "No lockfile found.
  Please specify your preferred \"package-manager\" in the action configuration."
      exit 1
  fi
  echo "VERSION=$VERSION" >> $GITHUB_ENV
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    INPUT_PM: yarn
Error: Process completed with exit code 1.
```

This is because it tries to find a lock file in the root directory rather than in the directory specified in `path`. This PR aims to fix it.