### PR TITLE
Fixed actions fails after update actions/deploy-pages to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install, build, and upload your site output
         uses: withastro/action@v1
         # with:
@@ -59,5 +59,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v3
 ```

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
         bun-version: ${{ env.VERSION }}
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       if: ${{ env.PACKAGE_MANAGER != 'bun' }}
       with:
         node-version: ${{ inputs.node-version }}
@@ -75,7 +75,7 @@ runs:
         cache-dependency-path: "${{ inputs.path }}/${{ env.LOCKFILE }}"
     
     - name: Setup Node (Bun)
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       if: ${{ env.PACKAGE_MANAGER == 'bun' }}
       with:
         node-version: ${{ inputs.node-version }}
@@ -93,6 +93,6 @@ runs:
         $PACKAGE_MANAGER run build
 
     - name: Upload Pages Artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "${{ inputs.path }}/dist/"


### PR DESCRIPTION
Actions fails after I update actions/deploy-pages to v4. So this PR will fix #33 and update some actions to lastest version.