### PR TITLE
use the latest version of `actions/setup-node`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
         bun-version: ${{ env.VERSION }}
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       if: ${{ env.PACKAGE_MANAGER != 'bun' }}
       with:
         node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
This pull request bumps the `actions/setup-node` Action to the latest version which is `v4`. There should not be any unexpected or breaking changes by bumping this version to the [v4 release](https://github.com/actions/setup-node/releases/tag/v4.0.0).