### PR TITLE
Pin `actions/upload-pages-artifact` to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: [edited]
+    types: [released, edited]
   workflow_dispatch:
     inputs:
       TAG_NAME:

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,7 @@ runs:
       run: $PACKAGE_MANAGER run build
 
     - name: Upload Pages Artifact
-      uses: actions/upload-pages-artifact@v3
+      # Must use v2 to avoid requiring `actions/deploy-pages@v4` or newer
+      uses: actions/upload-pages-artifact@v2
       with:
         path: "${{ inputs.path }}/dist/"

--- a/action.yml
+++ b/action.yml
@@ -94,4 +94,4 @@ runs:
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: "${{ inputs.path }}/dist"
+        path: "${{ inputs.path }}/dist/"


### PR DESCRIPTION
Related to https://github.com/withastro/action/issues/37

Turns out that bumping to `actions/upload-pages-artifact@v3` is quite a breaking change, so we need to use `actions/upload-pages-artifact@v2` on the v1 release line. We can bump to `v3` on our own `v2` line. See [GitHub Actions – Artifacts v4 is now Generally Available
](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/) for more information.