### PR TITLE
Upgrade action versions and default to node 20

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -8,7 +8,7 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
         id: update-major-tag
-        uses: actions/publish-action@v0.2.2
+        uses: actions/publish-action@v0.3.0
         with:
           source-tag: ${{ env.TAG_NAME }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information, please see our complete deployment guide—[Deploy your As
 ### Inputs
 
 - `path` - Optional: the root location of your Astro project inside the repository.
-- `node-version` - Optional: the specific version of Node that should be used to build your site. Defaults to `18`.
+- `node-version` - Optional: the specific version of Node that should be used to build your site. Defaults to `20`.
 - `package-manager` - Optional: the Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. Accepted values: `npm`, `yarn`, `pnpm`, and `bun`. A version tag is also accepted, for example `npm@18.14.1`, `pnpm@8`, or `bun@latest`. If not provided, version will default to `latest`.
 
 ### Example workflow:
@@ -44,10 +44,10 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
       - name: Install, build, and upload your site output
-        uses: withastro/action@v1
+        uses: withastro/action@v2
         # with:
             # path: . # The root location of your Astro project inside the repository. (optional)
-            # node-version: 18 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
+            # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
             # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:
@@ -59,5 +59,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   node-version:
     description: "The node version to use"
     required: false
-    default: "18"
+    default: "20"
   package-manager:
     description: "You may specify your preferred package manager (one of `npm | yarn | pnpm | bun` and an optional `@<version>` tag). Otherwise, the package manager will be automatically detected."
     required: false
@@ -92,7 +92,6 @@ runs:
       run: $PACKAGE_MANAGER run build
 
     - name: Upload Pages Artifact
-      # Must use v2 to avoid requiring `actions/deploy-pages@v4` or newer
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "${{ inputs.path }}/dist/"


### PR DESCRIPTION
As stated in the issue here https://github.com/withastro/action/issues/40, current `withastro/action` does not work with `action/deploy-pages@v4` and upgrading to actions using node 20 is not possible. 

This pull request would make v2 release for your action. I tested it with application built with `npm` and built it using an action published from a [fork](https://github.com/LeadingMoominExpert/withastro-action), and a workflow file like
```yaml
name: Deploy

on:
  push:
    branches:
    - main
  workflow_dispatch:

permissions:
  contents: read
  pages: write
  id-token: write

jobs:
  build:
    runs-on: ubuntu-latest
    timeout-minutes: 15
    steps:
      - name: Checkout your repository using git
        uses: actions/checkout@v4

      - name: Install, build, and upload your site
        uses: LeadingMoominExpert/withastro-action@v2

  deploy:
    needs: build
    timeout-minutes: 15
    runs-on: ubuntu-latest
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}

    steps:
      - name: Deploy to GitHub Pages
        id: deployment
        uses: actions/deploy-pages@v4
```
Note that the example uses `actions/deploy-pages@v4`, which was not previously possible 

Resolves https://github.com/withastro/action/issues/40