### PR TITLE
Bump pnpm/action-setup to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Setup PNPM
       if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v3
       with:
         version: ${{ env.VERSION }}
     


### PR DESCRIPTION
Bump `pnpm/action-setup` to `v3` to fix the following warning:
```txt
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```