### PR TITLE
add optional build output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For more information, please see our complete deployment guide—[Deploy your As
 ### Inputs
 
 - `path` - Optional: the root location of your Astro project inside the repository.
+- `out` - optional: Path of the directory containing the output build same as for outDir. Needed if path is specified.
 - `node-version` - Optional: the specific version of Node that should be used to build your site. Defaults to `20`.
 - `package-manager` - Optional: the Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. Accepted values: `npm`, `yarn`, `pnpm`, and `bun`. A version tag is also accepted, for example `npm@18.14.1`, `pnpm@8`, or `bun@latest`. If not provided, version will default to `latest`.
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Path of the directory containing your site"
     required: false
     default: "."
+  out:
+    description: "Path of the directory containing the output build same as for outDir"
+    required: false
+    default: "${{ inputs.path }}/dist/"
 
 runs:
   using: composite
@@ -94,4 +98,4 @@ runs:
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: "${{ inputs.path }}/dist/"
+        path: "${{ inputs.out }}/"

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,9 @@ inputs:
     required: false
     default: "."
   out:
-    description: "Path of the directory containing the output build same as for outDir"
+    description: "Path of the directory containing the output build same as for outDir. Needed if inputs.path is specified."
     required: false
-    default: "${{ inputs.path }}/dist/"
+    default: "./dist"
 
 runs:
   using: composite


### PR DESCRIPTION
This is a suggestion to enable the inputs.out definition as this action currently does not allow usage of the astro config outDir.
If outDir is different than './dist' then users can specify it in the out input.
I was hesitant to call it differently like outDir our out-dir to avoid any naming case convention conflict.
The only catch is that if path is specified, then out must necessarily also be specified, which is mentioned in the description