### PR TITLE
Fix check for lockfiles depth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,17 +35,17 @@ runs:
               VERSION="latest"
           fi
           echo "PACKAGE_MANAGER=$PACKAGE_MANAGER" >> $GITHUB_ENV
-        elif [ $(find "." -name "pnpm-lock.yaml") ]; then
+        elif [ $(find "." -maxdepth 1 -name "pnpm-lock.yaml") ]; then
             echo "PACKAGE_MANAGER=pnpm" >> $GITHUB_ENV
             echo "LOCKFILE=pnpm-lock.yaml" >> $GITHUB_ENV
-        elif [ $(find "." -name "yarn.lock") ]; then 
+        elif [ $(find "." -maxdepth 1 -name "yarn.lock") ]; then
             echo "PACKAGE_MANAGER=yarn" >> $GITHUB_ENV
             echo "LOCKFILE=yarn.lock" >> $GITHUB_ENV
-        elif [ $(find "." -name "package-lock.json") ]; then 
+        elif [ $(find "." -maxdepth 1 -name "package-lock.json") ]; then
             VERSION="latest"
             echo "PACKAGE_MANAGER=npm" >> $GITHUB_ENV
             echo "LOCKFILE=package-lock.json" >> $GITHUB_ENV
-        elif [ $(find "." -name "bun.lockb") ]; then 
+        elif [ $(find "." -maxdepth 1 -name "bun.lockb") ]; then
             VERSION="latest"
             echo "PACKAGE_MANAGER=bun" >> $GITHUB_ENV
             echo "LOCKFILE=bun.lockb" >> $GITHUB_ENV


### PR DESCRIPTION
## The Issue

At DDEV we run linter before executing this action:

https://github.com/ddev/ddev.com/blob/7a849588830da831a94f356877abee6d08a458a9/.github/workflows/test.yml

```yaml
jobs:
  build:
    timeout-minutes: 15
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: actions/setup-node@v3
        with:
          node-version: 20
      - name: Install dependencies
        run: npm ci
      - name: Lint
        run: npm run textlint
      - name: Install, build, and upload your site output
        uses: withastro/action@v2
```

And your action use `find` to check for `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json` and `bun.lockb` without a specific depth, which resulted in:

```
find "." -name "yarn.lock"
./node_modules/uri-js/yarn.lock
```

And our tests failed with (we use `npm`):
```
Warning: No existing directories found containing cache-dependency-path="./yarn.lock"
```

## How This PR Solves The Issue

Use `-maxdepth 1` as it makes no sense to search all subdirectories for lockfiles.