### PR TITLE
Specify location of package.json field for PNPM install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,7 @@ runs:
       uses: pnpm/action-setup@v3
       with:
         version: ${{ env.VERSION }}
+        package_json_file: "${{ inputs.path }}/package.json"
     
     - name: Setup Bun
       if: ${{ env.PACKAGE_MANAGER == 'bun' }}


### PR DESCRIPTION
When using a custom path, the PNPM installer seems to need to know where the package.json is, which isn't in the root.

This was also seen in this issue: https://github.com/withastro/action/issues/50
But the user just did a workaround.