### PR TITLE
Bump pnpm/action-setup to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Setup PNPM
       if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v4
       with:
         version: ${{ env.VERSION }}
         package_json_file: "${{ inputs.path }}/package.json"


### PR DESCRIPTION
Bump `pnpm/action-setup` to `v4` to fix 'ERR_INVALID_THIS' in Node 20
If we use the default configuration without modification, this error will occur

see: 
- https://github.com/pnpm/pnpm/issues/6424
- https://github.com/pnpm/action-setup/issues/135