### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,11 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [main]
+    branches: [master, main]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
 # Allow this job to clone the repo and create a page deployment
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -43,8 +39,11 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      - name: Install, build, and upload your site output
-        uses: withastro/action@v2
+        with:
+          persist-credentials: false
+
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3
         # with:
             # path: . # The root location of your Astro project inside the repository. (optional)
             # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
@@ -53,6 +52,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Using [zizmor](https://github.com/woodruffw/zizmor) these errors were resolved in the example workflow.

```
21 |         - name: Checkout your repository using git
   |  _________-
22 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[excessive-permissions]: overly broad workflow or job-level permissions
  --> \\?\I:\repo\.github\workflows\test.yml:12:1
   |
12 | / permissions:
13 | |   contents: read
14 | |   pages: write
15 | |   id-token: write
   | |_________________^ pages: write is overly broad at the workflow level
   |
   = note: audit confidence → High

error[excessive-permissions]: overly broad workflow or job-level permissions
  --> \\?\I:\repo\.github\workflows\test.yml:12:1
   |
12 | / permissions:
13 | |   contents: read
14 | |   pages: write
15 | |   id-token: write
   | |_________________^ id-token: write is overly broad at the workflow level
   |
   = note: audit confidence → High

6 findings (3 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 2 high
```