### PR TITLE
bumping to v4 because v3 is deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,6 @@ runs:
       run: $PACKAGE_MANAGER run build
 
     - name: Upload Pages Artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: "${{ inputs.path }}/dist/"


### PR DESCRIPTION
bumping to v4 because v3 is deprecated https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes (no breaking changes that we use)