### PR TITLE
fix(action): don't rely on `package.json` aliases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
     - name: Build
       shell: "bash"
       working-directory: ${{ inputs.path }}
-      run: $PACKAGE_MANAGER run build
+      run: $PACKAGE_MANAGER run astro build
 
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
After deleting the `"build": "astro build"` from my `package.json`, this action stopped working!

Now it should work regardless of the `scripts` in a user's `package.json`.