### PR TITLE
feat(input): add optional `build-cmd` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ For more information, please see our complete deployment guide—[Deploy your As
 - `path` - Optional: the root location of your Astro project inside the repository.
 - `node-version` - Optional: the specific version of Node that should be used to build your site. Defaults to `22`.
 - `package-manager` - Optional: the Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. Accepted values: `npm`, `yarn`, `pnpm`, and `bun`. A version tag is also accepted, for example `npm@18.14.1`, `pnpm@8`, or `bun@latest`. If not provided, version will default to `latest`.
+- `build-cmd` - Optional: the command to run to build your site. Defaults to `deno task build` for sites using Deno and to `<package-manager> run build` for all other package managers.
 
 ### Example workflow:
 
@@ -49,6 +50,7 @@ jobs:
             # path: . # The root location of your Astro project inside the repository. (optional)
             # node-version: 22 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
             # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+            # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
 
   deploy:
     needs: build

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Path of the directory containing your site"
     required: false
     default: "."
+  build-cmd:
+    description: "The command used to build your site"
+    required: false
+    default: "$PACKAGE_MANAGER run build"
 
 runs:
   using: composite
@@ -94,7 +98,7 @@ runs:
     - name: Build
       shell: "bash"
       working-directory: ${{ inputs.path }}
-      run: $PACKAGE_MANAGER run build
+      run: ${{ inputs.build-cmd }}
 
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v3

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   build-cmd:
     description: "The command used to build your site"
     required: false
-    default: ""
+    default:
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   build-cmd:
     description: "The command used to build your site"
     required: false
-    default: "$PACKAGE_MANAGER run build"
+    default: ""
 
 runs:
   using: composite
@@ -135,13 +135,13 @@ runs:
       if: ${{ env.PACKAGE_MANAGER != 'deno' }}
       shell: bash
       working-directory: ${{ inputs.path }}
-      run: ${{ inputs.build-cmd }}
+      run: ${{ inputs.build-cmd || '$PACKAGE_MANAGER run build' }}
 
     - name: Build (Deno)
       if: ${{ env.PACKAGE_MANAGER == 'deno' }}
       shell: bash
       working-directory: ${{ inputs.path }}
-      run: deno task build
+      run: ${{ inputs.build-cmd || 'deno task build' }}
 
     - name: Upload Pages Artifact
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Currently still defaults to using the `build` script defined in `package.json`, though this default may change in the future.