### PR TITLE
Use latest PNPM version if not specified

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
             echo "PACKAGE_MANAGER=pnpm" >> $GITHUB_ENV
             echo "LOCKFILE=pnpm-lock.yaml" >> $GITHUB_ENV
             # If packageManager field is not present, use latest version.
-            if ! grep -q "\"packageManager\":"  package.json; then
+            if ! jq -e '.packageManager' package.json > /dev/null 2>&1; then
                 VERSION="latest"
                 # Annotate this action run to let users know we’re using the default.
                 echo "::warning title=Could not detect PNPM version::No \`packageManager\` field found in \`package.json\`. Using latest PNPM version instead. We recommend specifying \`pnpm@VERSION\` explicitly using the \`packageManager\` field in your \`package.json\`."

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,12 @@ runs:
         elif [ $(find "." -maxdepth 1 -name "pnpm-lock.yaml") ]; then
             echo "PACKAGE_MANAGER=pnpm" >> $GITHUB_ENV
             echo "LOCKFILE=pnpm-lock.yaml" >> $GITHUB_ENV
+            # If packageManager field is not present, use latest version.
+            if ! grep -q "\"packageManager\":"  package.json; then
+                VERSION="latest"
+                # Annotate this action run to let users know we’re using the default.
+                echo "::warning title=Could not detect PNPM version::No `packageManager` field found in `package.json`. Using latest PNPM version instead. We recommend specifying `pnpm@VERSION` explicitly using the `packageManager` field in your `package.json`."
+            fi
         elif [ $(find "." -maxdepth 1 -name "yarn.lock") ]; then
             echo "PACKAGE_MANAGER=yarn" >> $GITHUB_ENV
             echo "LOCKFILE=yarn.lock" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
             if ! grep -q "\"packageManager\":"  package.json; then
                 VERSION="latest"
                 # Annotate this action run to let users know we’re using the default.
-                echo "::warning title=Could not detect PNPM version::No `packageManager` field found in `package.json`. Using latest PNPM version instead. We recommend specifying `pnpm@VERSION` explicitly using the `packageManager` field in your `package.json`."
+                echo "::warning title=Could not detect PNPM version::No \`packageManager\` field found in \`package.json\`. Using latest PNPM version instead. We recommend specifying \`pnpm@VERSION\` explicitly using the \`packageManager\` field in your \`package.json\`."
             fi
         elif [ $(find "." -maxdepth 1 -name "yarn.lock") ]; then
             echo "PACKAGE_MANAGER=yarn" >> $GITHUB_ENV


### PR DESCRIPTION
Closes #80

This PR updates the action to check if a `packageManager` field is present when someone is using PNPM. If it isn’t, https://github.com/pnpm/action-setup won’t be able to detect the version to use, so we set it to `latest` and add a warning to the action run letting people know that an explicit version is recommended.