### PR TITLE
Update action.yml to use specific version tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,25 +80,25 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Setup PNPM
       if: ${{ env.PACKAGE_MANAGER == 'pnpm' }}
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       with:
         version: ${{ env.VERSION }}
         package_json_file: "${{ inputs.path }}/package.json"
     
     - name: Setup Bun
       if: ${{ env.PACKAGE_MANAGER == 'bun' }}
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
       with:
         bun-version: ${{ env.VERSION }}
 
     - name: Setup Deno
       if: ${{ env.PACKAGE_MANAGER == 'deno' }}
-      uses: denoland/setup-deno@v2
+      uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
       with:
         deno-version: ${{ env.VERSION }}
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       if: ${{ env.PACKAGE_MANAGER != 'bun' && env.PACKAGE_MANAGER != 'deno' }}
       with:
         node-version: ${{ inputs.node-version }}
@@ -106,7 +106,7 @@ runs:
         cache-dependency-path: "${{ inputs.path }}/${{ env.LOCKFILE }}"
     
     - name: Setup Node (Bun)
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       if: ${{ env.PACKAGE_MANAGER == 'bun' }}
       with:
         node-version: ${{ inputs.node-version }}
@@ -144,6 +144,6 @@ runs:
       run: ${{ inputs.build-cmd || 'deno task build' }}
 
     - name: Upload Pages Artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
       with:
         path: "${{ inputs.path }}/dist/"


### PR DESCRIPTION
## Description

Update the used actions to the pinned version of themselves

## Links 
https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1 ( skipped v4, out of scope )
https://github.com/actions/setup-node/releases/tag/v4.4.0 ( skipped v5, out of scope)
https://github.com/pnpm/action-setup/releases/tag/v4.1.0
https://github.com/denoland/setup-deno/releases/tag/v2.0.3

close #82