### PR TITLE
fix(action): set LOCKFILE when package-manager is explicitly specified (#98)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,20 @@ runs:
               fi
           fi
           echo "PACKAGE_MANAGER=$PACKAGE_MANAGER" >> $GITHUB_ENV
+          case "$PACKAGE_MANAGER" in
+            yarn) LOCKFILE="yarn.lock" ;;
+            npm)  LOCKFILE="package-lock.json" ;;
+            pnpm) LOCKFILE="pnpm-lock.yaml" ;;
+            bun)  [ -f "bun.lock" ] && LOCKFILE="bun.lock" || LOCKFILE="bun.lockb" ;;
+            deno) LOCKFILE="deno.lock" ;;
+          esac
+          if [ -n "$LOCKFILE" ]; then
+            if [ -f "$LOCKFILE" ]; then
+              echo "LOCKFILE=$LOCKFILE" >> $GITHUB_ENV
+            else
+              echo "::warning title=Lockfile not found::No \`$LOCKFILE\` found; node_modules caching will be skipped."
+            fi
+          fi
         elif [ $(find "." -maxdepth 1 -name "pnpm-lock.yaml") ]; then
             echo "PACKAGE_MANAGER=pnpm" >> $GITHUB_ENV
             echo "LOCKFILE=pnpm-lock.yaml" >> $GITHUB_ENV
@@ -109,13 +123,21 @@ runs:
       with:
         deno-version: ${{ env.VERSION }}
 
-    - name: Setup Node
+    - name: Setup Node (with lockfile cache)
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-      if: ${{ env.PACKAGE_MANAGER != 'bun' && env.PACKAGE_MANAGER != 'deno' }}
+      if: ${{ env.PACKAGE_MANAGER != 'bun' && env.PACKAGE_MANAGER != 'deno' && env.LOCKFILE != '' }}
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ env.PACKAGE_MANAGER }}
         cache-dependency-path: "${{ inputs.path }}/${{ env.LOCKFILE }}"
+
+    - name: Setup Node (without lockfile cache)
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      if: ${{ env.PACKAGE_MANAGER != 'bun' && env.PACKAGE_MANAGER != 'deno' && env.LOCKFILE == '' }}
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache:
+        package-manager-cache: false
 
     - name: Setup Node (Bun)
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
Fixes [#98](https://github.com/withastro/action/issues/98#issue-4133865815).

## Note well

I have prepared this PR with the help of Claude Code and ChatGPT Codex, using them to cross-check each other's work.  I have personally reviewed the code thoroughly, as well as this PR, but as I don't personally know some of the package managers involved, there may be subtle bugs that have gone unnoticed.

## What was wrong

When `package-manager` is explicitly set by the user, the "Check lockfiles" step in `action.yml` sets `PACKAGE_MANAGER` but never `LOCKFILE`. All auto-detection branches set both; the explicit branch sets only the former.

With `LOCKFILE` unset, `cache-dependency-path` gets evaluated to `"./"`, which gets expanded in `actions/setup-node` recursively to every file in the workspace; see [#98](https://github.com/withastro/action/issues/98#issue-4133865815).

## Changes

**`action.yml`**

1. "Check lockfiles" step:

After `PACKAGE_MANAGER` is set in the explicit branch, a `case` statement maps it to the expected lockfile name. `LOCKFILE` is written to `$GITHUB_ENV` only if the named file exists on disk. If the file does not exist, e.g. because the lockfile is gitignored, a warning annotation is emitted and `LOCKFILE` is left unset.

2. Setup Node steps:

The single "Setup Node" step is split into two mutually exclusive steps conditioned on `env.LOCKFILE`:

- **with lockfile cache** (`env.LOCKFILE != ''`): behaviour unchanged from before — passes `cache` and `cache-dependency-path` as before.
 
- **without lockfile cache** (`env.LOCKFILE == ''`): sets `cache:` to empty and `package-manager-cache: false` to fully disable node_modules caching and  avoid a hard failure from `actions/setup-node`.
